### PR TITLE
Adding in Github creds from context for use with private repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # prebuild-orb CHANGELOG
 
+## 1.0.15 (2019-11-15)
+
+- [murray.butler] - add github creds for private repos
+
 ## 1.0.14 (2019-10-11)
 
 - [corey.hemminger] - fix publishing twice

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# prbuild-orb
+# prebuild-orb
 
 [![CircleCI](https://circleci.com/gh/netgaintechnology/orb-prebuild-orb.svg?style=svg)](https://circleci.com/gh/netgaintechnology/orb-prebuild-orb) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 

--- a/src/jobs/terraform_lint.yml
+++ b/src/jobs/terraform_lint.yml
@@ -10,6 +10,7 @@ parameters:
     description: |
       Directory within to lint all terraform files,
       defaults to the working directory (.)
+
   tf-workspace:
     type: string
     default: dev
@@ -24,6 +25,27 @@ steps:
         credentials "app.terraform.io" {
           token = "$TFIO_TOKEN"
         }
+
+# Add Github creds for private repo use, conditional on env vars being present
+  - when:
+      condition: $GITHUB_USER
+      steps:
+        - run:
+            name: Set Github User
+            command: |
+              echo "https://$GITHUB_USER:$GITHUB_TOKEN@github.com" > ~/.git-credentials
+
+  - when:
+      condition: $GITHUB_USER
+      steps:
+        - run:
+            name: Set Github Cred Helper
+            command: |
+              echo "[user]"  > ~/.gitconfig
+              echo "  name = $GITHUB_USER" >> ~/.gitconfig
+              echo "[credential]" >> ~/.gitconfig
+              echo "  helper = store" >> ~/.gitconfig
+
   - run: terraform workspace new <<parameters.tf-workspace>>
   - run: terraform init -upgrade <<parameters.lint-dir>>
   - run: terraform validate <<parameters.lint-dir>>


### PR DESCRIPTION
### Checklist

<!--
     Added when clauses for addition of GITHUB_USER and GITHUB_TOKEN vars for credentialed access to private github repos of modules.
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	Private github repos require credentials for download.  To run terraform with those modules, GITHUB_USER and GITHUB_TOKEN were required.
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
