### PR TITLE
Add linting job for modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 orbs:
   cli: circleci/circleci-cli@volatile
   prebuild-orb: netgaintechnology/prebuild-orb@dev:alpha
-  orb-tools: circleci/orb-tools@volatile
+  orb-tools: circleci/orb-tools@8.27.6
 
 commands:
   pack-validate-orb:

--- a/src/jobs/terraform_module_lint.yml
+++ b/src/jobs/terraform_module_lint.yml
@@ -1,0 +1,60 @@
+description: |
+  terraform linting
+
+executor: terraform
+
+parameters:
+  lint-dir:
+    type: string
+    default: .
+    description: |
+      Directory within to lint all terraform files,
+      defaults to the working directory (.)
+
+  tf-workspace:
+    type: string
+    default: dev
+    description: |
+      Terraform workspace to use
+
+steps:
+  - update_alpine_and_checkout
+  # Terraform Cloud Access
+  - run: |
+      echo "# Terraform CLI config" > ~/.terraformrc
+      echo "credentials \"app.terraform.io\" {" >> ~/.terraformrc
+      echo "  token = \"$TFIO_TOKEN\"" >> ~/.terraformrc
+      echo "}" >> ~/.terraformrc
+  # AWS Cloud Access
+  - run: |
+      mkdir ~/.aws
+      echo "[default]" > ~/.aws/credentials
+      echo "aws_access_key_id = $AWS_ACCESS_KEY_ID-<<parameters.tf-workspace>>" >> ~/.aws/credentials
+      echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY-<<parameters.tf-workspace>>" >> ~/.aws/credentials
+  # Azure Cloud Access
+  - run: |
+      mkdir ~/.azure
+      echo "[default]"
+      echo "subscription_id=$AZURE_SUBSCRIPTION_ID-<<parameters.tf-workspace>>]" > ~/.azure/credentials
+      echo "client_id=$AZURE_CLIENT_ID-<<parameters.tf-workspace>>" >> ~/.azure/credentials
+      echo "secret=$AZURE_CLIENT_SECRET-<<parameters.tf-workspace>>" >> ~/.azure/credentials
+      echo "tenant_id=$AZURE_TENANT_ID-<<parameters.tf-workspace>>" >> ~/.azure/credentials
+  # GITHUB Private Repo Access
+  - run: |
+      echo "https://$GITHUB_USER:$GITHUB_TOKEN@github.com" > ~/.git-credentials
+      echo "[user]"  > ~/.gitconfig
+      echo "  name = $GITHUB_USER" >> ~/.gitconfig
+      echo "[credential]" >> ~/.gitconfig
+      echo "  helper = store" >> ~/.gitconfig
+  # Real work
+  - run: terraform workspace new <<parameters.tf-workspace>>
+  - run: terraform init -upgrade <<parameters.lint-dir>>
+  - run: 
+      command: terraform validate <<parameters.lint-dir>>
+      environment: 
+        AWS_DEFAULT_REGION: us-west-2
+  - run: |
+      if [[ -n "$(terraform fmt -check -recursive <<parameters.lint-dir>>)" ]]; then
+      echo "Some terraform files need be formatted, run 'terraform fmt' to fix";
+      exit 1;
+      fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	With TF 0.12, the validate arg now REQUIRES the region be set.  The workaround for this is to have the environment var set for AWS_DEFAULT_REGION in the step, since CircleCI is poor at passing the var to an orb from the calling job.  
-->

### Description

<!---
 Replicated terraform linting job and added env var for fake AWS_DEFAULT_REGION.  Since validate does NOT perform any operations on the cloud provider, the region is insignificant, but required for the command.
 -->
